### PR TITLE
Fix lint error: file exists

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
+          skip-pkg-cache: true
           go-version: "1.19"
-      - uses: golangci/golangci-lint-action@v3     
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          skip-pkg-cache: true
+          args: --timeout=3m
+          version: v1.52.2          


### PR DESCRIPTION
`skip-pkg-cache: true` this is needed to avoid running into golangci/golangci-lint-action#135.