### PR TITLE
Feat: change token denom

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -42,7 +42,7 @@ const (
 const (
 	// DisplayDenom defines the denomination displayed to users in client applications.
 	DisplayDenom = "otto"
-	// BaseDenom defines to the default denomination used in Evmos (staking, EVM, governance, etc.)
+	// BaseDenom defines to the default denomination used in Ottochain (staking, EVM, governance, etc.)
 	BaseDenom = "aotto"
 )
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Bech32Prefix defines the Bech32 prefix used for EthAccounts
-	Bech32Prefix = "oct"
+	Bech32Prefix = "otto"
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address
 	Bech32PrefixAccAddr = Bech32Prefix
@@ -41,9 +41,9 @@ const (
 
 const (
 	// DisplayDenom defines the denomination displayed to users in client applications.
-	DisplayDenom = "oct"
+	DisplayDenom = "otto"
 	// BaseDenom defines to the default denomination used in Evmos (staking, EVM, governance, etc.)
-	BaseDenom = "aoct"
+	BaseDenom = "aotto"
 )
 
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.

--- a/cmd/ottod/testnet.go
+++ b/cmd/ottod/testnet.go
@@ -217,7 +217,7 @@ func initTestnetFiles(
 	if args.chainID == "" {
 		args.chainID = fmt.Sprintf("otto_%d-1", tmrand.Int63n(9999999999999)+1)
 	}
-	// if args.minGasPrices == "0aoct" {
+	// if args.minGasPrices == "0aotto" {
 	// 	args.minGasPrices = fmt.Sprintf("7%s", cmdcfg.BaseDenom)
 	// }
 	nodeIDs := make([]string, args.numValidators)

--- a/scripts/setup_genesis.sh
+++ b/scripts/setup_genesis.sh
@@ -2,7 +2,7 @@
 
 CHAIN="otto"
 # set denom
-DENOM="aoct"
+DENOM="aotto"
 CHAINID="$CHAIN"_9100-1
 MONIKER="orchestrator"
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -48,7 +48,7 @@ This will create a Hardhat config file (`hardhat.config.js`) in your project dir
 
 Before you can write and deploy the contract to OttoChain Testnet, you'll need to modify the Hardhat configuration file.
 
-Then you can create a `secrets.json` file under the project directory to store the private key of the pre-funded account `test` which has some `OCT` tokens in OttoChain Testnet by running:
+Then you can create a `secrets.json` file under the project directory to store the private key of the pre-funded account `test` which has some `OTTO` tokens in OttoChain Testnet by running:
 
 ```
 touch secrets.json


### PR DESCRIPTION
The community chain Ottochain would be separate from the OCT economy. To avoid misunderstanding, we could change the token to OTTO.
